### PR TITLE
Adding copy-to-clipboard buttons.

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -4,6 +4,29 @@ var markup;
 var ServerURL = 'https://xf79h9aa3l.execute-api.us-west-2.amazonaws.com/toolkit2';
 var ThumbURL = 'https://developer.api.autodesk.com/modelderivative/v2/designdata';
 
+// Setup copy-to-clipboard buttons
+if ('clipboard' in navigator && location.protocol === 'https:') {
+    function setup(button, input) {
+        button.addEventListener('click', async function() {
+            button.innerHTML = '...';
+            try {
+                await navigator.clipboard.writeText(input.value);
+            } catch(err) {
+                alert('Could not copy to clipboard (' + err + ')');
+            } finally {
+                button.innerHTML = 'Copy';
+            }
+        });
+    }
+    setup(document.querySelector('#urn button'), document.querySelector('#urn input'))
+    setup(document.querySelector('#token button'), document.querySelector('#token input'))
+    setup(document.querySelector('#scene button'), document.querySelector('#scene input'))
+} else {
+    document.querySelector('#urn button').style.setProperty('display', 'none');
+    document.querySelector('#token button').style.setProperty('display', 'none');
+    document.querySelector('#scene button').style.setProperty('display', 'none');
+}
+
 // Vue.js components
 window.app = new Vue({
     el: "#app",

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,8 +5,16 @@
 	<link rel="stylesheet" href="./skeleton.min.css">
 	<link rel="shortcut icon" href="#">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.1.6/vue.min.js"></script>
+  <style>
+    #urn button, #token button, #scene button {
+      height: 1.7em;
+      padding: 0.3em;
+      line-height: 0;
+      font-weight: inherit;
+      text-transform: none;
+    }
+  </style>
 </head>
-
 
 <body style="margin:0; overflow-y: hidden;">
   <div id="app">
@@ -30,9 +38,21 @@
 
   <div class="container overlay" style="left: 1em; top: 15em; width:250px">
     {{form.title}}
-    <div class="row"><div class="three columns">URN:</div><div class="nine columns"><input placeholder="URN" class="u-full-width" v-model="form.urn"></div> </div>
-      <div class="row"><div class="three columns">Token:</div><div class="nine columns"><input placeholder="TOKEN" class="u-full-width" v-model="form.token"></div> </div>
-      <div class="row"><div class="three columns">Scene:</div><div class="nine columns"><input placeholder="SCENE" class="u-full-width" v-model="form.scene"></div> </div>
+      <div id="urn" class="row">
+        <div class="three columns">URN:</div>
+        <div class="six columns"><input placeholder="URN" class="u-full-width" v-model="form.urn"></div>
+        <div class="three columns"><button>Copy</button></div>
+      </div>
+      <div id="token" class="row">
+        <div class="three columns">Token:</div>
+        <div class="six columns"><input placeholder="TOKEN" class="u-full-width" v-model="form.token"></div>
+        <div class="three columns"><button>Copy</button></div>
+      </div>
+      <div id="scene" class="row">
+        <div class="three columns">Scene:</div>
+        <div class="six columns"><input placeholder="SCENE" class="u-full-width" v-model="form.scene"></div>
+        <div class="three columns"><button>Copy</button></div>
+      </div>
   </div>
   <div id="toast" v-bind:class="{ show: istoast }">{{toastmsg}}</div>
 


### PR DESCRIPTION
Added copy-to-clipboard buttons next to the urn, token, scene input fields, using the [Async Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API). If the API is not available, or if not serving over HTTPS (which is required for the API), the buttons are hidden.